### PR TITLE
Add support of manually turning on and off a switch

### DIFF
--- a/src/WemoSwitch.cpp
+++ b/src/WemoSwitch.cpp
@@ -122,8 +122,8 @@ void WemoSwitch::handleUpnpControl(){
       and (request.indexOf("<BinaryState>1</BinaryState>") > 0)
     ) {
       Serial.println("Got Turn on request");
-      onCallback();
       deviceStatus = "1";
+      onCallback();
       response_xml =  "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
                         "<s:Body>"
                           "<u:SetBinaryStateResponse xmlns:u=\"urn:Belkin:service:basicevent:1\">"
@@ -139,8 +139,8 @@ void WemoSwitch::handleUpnpControl(){
       and (request.indexOf("<BinaryState>0</BinaryState>") > 0)
     ) {
       Serial.println("Got Turn off request");
-      offCallback();
       deviceStatus = "0";
+      offCallback();
       response_xml =  "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
                         "<s:Body>"
                           "<u:SetBinaryStateResponse xmlns:u=\"urn:Belkin:service:basicevent:1\">"

--- a/src/WemoSwitch.h
+++ b/src/WemoSwitch.h
@@ -32,6 +32,8 @@ public:
         String getAlexaInvokeName();
         void serverLoop();
         void respondToSearch(IPAddress& senderIP, unsigned int senderPort);
+        void turnOff() { deviceStatus = "0"; }
+        void turnOn() { deviceStatus = "1"; }
 };
 
 #endif


### PR DESCRIPTION
First thank you for the great repo. It helped me a lot in building an alexa-supported wireless security camera.

During the development, I found a useful scenario as a stateless operation. For example, I want my phone to pop up a IFTTT notification when I instruct Alexa to do so. However, "alexa turn on the camera" won't do anything if the device is already on. And memorizing the device's state is quite unpractical. So I manually turn off the device immediately after it executes the turning on callback. This makes "alexa turn on the camera" always work.

This works after some minor tweaks on the code. While I've tested on my device, also wanted to see whether this may benefit the upstream. That's why I sent out this PR. :)

Thanks again for this repo and hope this PR helps.